### PR TITLE
Improve font family handling for Jetpack Compose

### DIFF
--- a/utils/dist/helpers/KotlinHelper.d.ts
+++ b/utils/dist/helpers/KotlinHelper.d.ts
@@ -11,9 +11,10 @@ export declare enum ImportFlag {
     BorderStroke = 7,
     Modifier = 8,
     Blur = 9,
-    FontWeight = 10,
-    TextDecoration = 11,
-    TextStyle = 12
+    FontFamily = 10,
+    FontWeight = 11,
+    TextDecoration = 12,
+    TextStyle = 13
 }
 /** Collect flags while generating literals, turn into imports at the end */
 export declare class ImportCollector {
@@ -65,6 +66,7 @@ export declare class KotlinHelper {
     static blurTokenValueToKotlin(blur: BlurTokenValue, allTokens: Map<string, Token>, options: InternalOptions, importCollector: ImportCollector): string;
     static fontWeightTokenValueToKotlin(value: AnyStringTokenValue, allTokens: Map<string, Token>, options: InternalOptions, importCollector: ImportCollector): string;
     static fontWeightIntToKotlin(weight: number, importCollector: ImportCollector): string;
+    static fontFamilyTokenValueToKotlin(value: AnyStringTokenValue, allTokens: Map<string, Token>, options: InternalOptions, importCollector: ImportCollector): string;
     static typographyTokenValueToKotlin(typography: TypographyTokenValue, allTokens: Map<string, Token>, options: InternalOptions, importCollector: ImportCollector): string;
 }
 export {};

--- a/utils/dist/helpers/KotlinHelper.js
+++ b/utils/dist/helpers/KotlinHelper.js
@@ -19,9 +19,10 @@ var ImportFlag;
     ImportFlag[ImportFlag["BorderStroke"] = 7] = "BorderStroke";
     ImportFlag[ImportFlag["Modifier"] = 8] = "Modifier";
     ImportFlag[ImportFlag["Blur"] = 9] = "Blur";
-    ImportFlag[ImportFlag["FontWeight"] = 10] = "FontWeight";
-    ImportFlag[ImportFlag["TextDecoration"] = 11] = "TextDecoration";
-    ImportFlag[ImportFlag["TextStyle"] = 12] = "TextStyle";
+    ImportFlag[ImportFlag["FontFamily"] = 10] = "FontFamily";
+    ImportFlag[ImportFlag["FontWeight"] = 11] = "FontWeight";
+    ImportFlag[ImportFlag["TextDecoration"] = 12] = "TextDecoration";
+    ImportFlag[ImportFlag["TextStyle"] = 13] = "TextStyle";
 })(ImportFlag || (exports.ImportFlag = ImportFlag = {}));
 /** Collect flags while generating literals, turn into imports at the end */
 class ImportCollector {
@@ -61,6 +62,8 @@ class ImportCollector {
             if (this.importFlags.has(ImportFlag.Blur))
                 importList.push("import androidx.compose.ui.draw.blur");
         }
+        if (this.importFlags.has(ImportFlag.FontFamily))
+            importList.push("import androidx.compose.ui.text.font.FontFamily");
         if (this.importFlags.has(ImportFlag.FontWeight))
             importList.push("import androidx.compose.ui.text.font.FontWeight");
         if (this.importFlags.has(ImportFlag.TextDecoration))
@@ -125,6 +128,8 @@ class KotlinHelper {
                 value = this.fontWeightTokenValueToKotlin(token.value, allTokens, actualOptions, importCollector);
                 break;
             case sdk_exporters_1.TokenType.fontFamily:
+                value = this.fontFamilyTokenValueToKotlin(token.value, allTokens, actualOptions, importCollector);
+                break;
             case sdk_exporters_1.TokenType.productCopy:
             case sdk_exporters_1.TokenType.string:
                 value = this.stringTokenValueToKotlin(token.value, allTokens, actualOptions);
@@ -362,6 +367,14 @@ class KotlinHelper {
                 return `FontWeight(${weight})`;
         }
     }
+    static fontFamilyTokenValueToKotlin(value, allTokens, options, importCollector) {
+        const reference = (0, TokenHelper_1.sureOptionalReference)(value.referencedTokenId, allTokens, options.allowReferences);
+        if (reference) {
+            return options.tokenToVariableRef(reference);
+        }
+        importCollector.use(ImportFlag.FontFamily);
+        return `FontFamily(\"${value.text}\")`;
+    }
     static typographyTokenValueToKotlin(typography, allTokens, options, importCollector) {
         // Reference full typography token if set
         const reference = (0, TokenHelper_1.sureOptionalReference)(typography.referencedTokenId, allTokens, options.allowReferences);
@@ -374,7 +387,9 @@ class KotlinHelper {
         const fontWeightRef = (0, TokenHelper_1.sureOptionalReference)(typography.fontWeight.referencedTokenId, allTokens, options.allowReferences);
         const decorationRef = (0, TokenHelper_1.sureOptionalReference)(typography.textDecoration.referencedTokenId, allTokens, options.allowReferences);
         // Calculate literals
-        const fontFamilyLit = fontFamilyRef ? options.tokenToVariableRef(fontFamilyRef) : `"${typography.fontFamily.text}"`;
+        const fontFamilyLit = fontFamilyRef
+            ? options.tokenToVariableRef(fontFamilyRef)
+            : this.fontFamilyTokenValueToKotlin(typography.fontFamily, allTokens, options, importCollector);
         const fontWeightLit = fontWeightRef
             ? options.tokenToVariableRef(fontWeightRef)
             : this.fontWeightIntToKotlin((0, TokenHelper_1.normalizeTextWeight)(typography.fontWeight.text), importCollector);


### PR DESCRIPTION
## Summary
- add new `FontFamily` import flag for Kotlin generation
- generate `FontFamily` instances for font family tokens
- use typed font families in typography exports

## Testing
- `npm run build` *(fails: Cannot find module '@supernovaio/sdk-exporters')*
- `npm run build` in jetpack compose exporter *(fails: 403 Forbidden - GET https://registry.npmjs.org/webpack)*

------
https://chatgpt.com/codex/tasks/task_e_6842e80ec3e883238fb1d9c01eba7d81