### PR TITLE
Add AGENTS.md for Cursor Cloud development environment

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,67 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+### Product overview
+
+This repository is a **monorepo of Supernova.io exporter plugins** — TypeScript packages that transform design-system tokens into production code (CSS, CSS-in-JS, Tailwind, Style Dictionary, Jetpack Compose, SVG-to-React). There is no web server or database; local development means building packages and running Jest tests.
+
+### Package layout
+
+| Path | Package | Notes |
+|------|---------|-------|
+| `utils/` | `@supernovaio/export-utils` | Shared helpers; **must be installed first** |
+| `exporters/css/` | CSS variables exporter | Depends on `file:../../utils` |
+| `exporters/css-in-js/` | CSS-in-JS exporter | Has Jest tests |
+| `exporters/jetpack-compose/` | Kotlin/Jetpack Compose exporter | |
+| `exporters/style-dictionary/` | Style Dictionary JSON exporter | |
+| `exporters/svg-to-react/` | SVG → React exporter | Uses `@supernovaio/export-helpers`, not `export-utils` |
+| `exporters/tailwind-4/` | Tailwind CSS v4 exporter | |
+
+Each package has its own `package.json` and `package-lock.json`. There is no root workspace or orchestration script.
+
+### Standard commands
+
+**Install dependencies (all packages):**
+```bash
+cd utils && npm install
+for dir in css css-in-js jetpack-compose style-dictionary svg-to-react tailwind-4; do
+  (cd "exporters/$dir" && npm install)
+done
+```
+
+**Run tests:**
+```bash
+cd utils && npm test                    # 146 tests
+cd exporters/css-in-js && npm test      # 13 tests
+```
+
+**Build exporter bundles (`dist/build.js`):**
+```bash
+cd exporters/<name> && npm run build
+```
+
+**Watch mode during development:**
+```bash
+cd utils && npm run dev                 # tsc --watch
+cd exporters/<name> && npm run dev      # webpack --watch
+```
+
+### Important gotcha: do not rebuild `utils/` unless you intend to
+
+Running `npm run build` in `utils/` recompiles `utils/dist/` from source via `tsc`. The committed `utils/dist/` is currently **out of sync** with `utils/helpers/KotlinHelper.ts` (the dist includes `colorFormat` in `TokenToKotlinOptions`; the source does not). Rebuilding utils breaks the **jetpack-compose** exporter build with a TypeScript error.
+
+For normal exporter development and testing:
+- Run `npm install` in `utils/` (uses committed `dist/`)
+- Run `npm test` in `utils/` (tests run against source via ts-jest)
+- Build individual exporters with `npm run build`
+
+Only rebuild `utils/` when you are intentionally updating shared helper source and will fix downstream type errors.
+
+### Lint / format
+
+There is no repo-wide lint script. Prettier config lives at `.prettierrc`. Individual exporter packages include Prettier as a devDependency but no `npm run lint` script.
+
+### End-to-end export
+
+Full export against a live design system requires the external [Supernova.io](https://supernova.io) platform. Local verification is: install → test → webpack build → confirm `dist/build.js` exists.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Documents the development environment setup for Cursor Cloud agents working on this Supernova exporters monorepo.

## Changes

- Add `AGENTS.md` with package layout, standard commands, and a critical gotcha about `utils/` rebuild behavior

## VM update script

On VM startup, dependencies are refreshed via `npm install` in `utils/` and each exporter package (no build steps).

## Verification performed

- Node.js v22.22.3, npm 10.9.7
- `utils`: 146 Jest tests passing
- `exporters/css-in-js`: 13 Jest tests passing
- All 6 exporters webpack build to `dist/build.js` successfully
- Hello-world demo: token naming + color formatting via `@supernovaio/export-utils`

## Notes

- No lint script exists in this repo (Prettier config only)
- Rebuilding `utils/` from source currently breaks `jetpack-compose` due to a source/dist type mismatch in `KotlinHelper` — documented in AGENTS.md
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-23841e09-3716-47c6-8b9a-ef323fd2bbc2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-23841e09-3716-47c6-8b9a-ef323fd2bbc2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

